### PR TITLE
Image Tracking Changes

### DIFF
--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -297,14 +297,38 @@ namespace xr
                     static inline Identifier NEXT_ID{ 0 };
                 };
                 
+                struct ImageTrackingBitmap
+                {
+                    uint8_t* data;
+                    uint32_t width;
+                    uint32_t height;
+                    uint32_t depth;
+                };
+
                 struct ImageTrackingResult
                 {
                     using Identifier = size_t;
                     const Identifier ID{ NEXT_ID++ };
+                    Space imageSpace;
+                    uint32_t index;
+                    std::string trackingState;
+                    uint32_t measuredWidthInMeters;
                     SceneObject::Identifier ParentSceneObjectID{ SceneObject::INVALID_ID };
 
                 private:
                     static inline Identifier NEXT_ID{ 0 };
+                };
+                
+                struct ImageTrackingScore
+                {
+                    static constexpr auto UNTRACKABLE{"untrackable"};
+                    static constexpr auto TRACKABLE{"trackable"};
+                };
+                
+                struct ImageTrackingState
+                {
+                    static constexpr auto TRACKED{"tracked"};
+                    static constexpr auto EMULATED{"emulated"};
                 };
 
                 std::vector<View>& Views;
@@ -328,6 +352,8 @@ namespace xr
                 ~Frame();
 
                 void GetHitTestResults(std::vector<HitResult>&, Ray, HitTestTrackableType) const;
+                std::vector<char*> CreateAugmentedImageDatabase(std::vector<ImageTrackingBitmap>) const;
+                std::vector<ImageTrackingResult> GetImageTrackingResults() const;
                 Anchor CreateAnchor(Pose, NativeAnchorPtr) const;
                 Anchor DeclareAnchor(NativeAnchorPtr) const;
                 void UpdateAnchor(Anchor&) const;

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -296,6 +296,16 @@ namespace xr
                 private:
                     static inline Identifier NEXT_ID{ 0 };
                 };
+                
+                struct ImageTrackingResult
+                {
+                    using Identifier = size_t;
+                    const Identifier ID{ NEXT_ID++ };
+                    SceneObject::Identifier ParentSceneObjectID{ SceneObject::INVALID_ID };
+
+                private:
+                    static inline Identifier NEXT_ID{ 0 };
+                };
 
                 std::vector<View>& Views;
                 std::vector<InputSource>& InputSources;
@@ -309,6 +319,8 @@ namespace xr
                 std::vector<Plane::Identifier>RemovedPlanes;
                 std::vector<Mesh::Identifier>UpdatedMeshes;
                 std::vector<Mesh::Identifier>RemovedMeshes;
+                std::vector<ImageTrackingResult::Identifier>UpdatedImageTrackingResults;
+                std::vector<ImageTrackingResult::Identifier>RemovedImageTrackingResults;
 
                 bool IsTracking;
 

--- a/Dependencies/xr/Include/XR.h
+++ b/Dependencies/xr/Include/XR.h
@@ -309,10 +309,10 @@ namespace xr
                 {
                     using Identifier = size_t;
                     const Identifier ID{ NEXT_ID++ };
-                    Space imageSpace;
-                    uint32_t index;
-                    std::string trackingState;
-                    uint32_t measuredWidthInMeters;
+                    Space ImageSpace;
+                    uint32_t Index;
+                    std::string TrackingState;
+                    uint32_t MeasuredWidthInMeters;
                     SceneObject::Identifier ParentSceneObjectID{ SceneObject::INVALID_ID };
 
                 private:
@@ -353,7 +353,6 @@ namespace xr
 
                 void GetHitTestResults(std::vector<HitResult>&, Ray, HitTestTrackableType) const;
                 std::vector<char*> CreateAugmentedImageDatabase(std::vector<ImageTrackingBitmap>) const;
-                std::vector<ImageTrackingResult> GetImageTrackingResults() const;
                 Anchor CreateAnchor(Pose, NativeAnchorPtr) const;
                 Anchor DeclareAnchor(NativeAnchorPtr) const;
                 void UpdateAnchor(Anchor&) const;
@@ -361,6 +360,7 @@ namespace xr
                 SceneObject& GetSceneObjectByID(SceneObject::Identifier) const;
                 Plane& GetPlaneByID(Plane::Identifier) const;
                 Mesh& GetMeshByID(Mesh::Identifier) const;
+                ImageTrackingResult& GetImageTrackingResultByID(ImageTrackingResult::Identifier) const;
 
             private:
                 struct Impl;

--- a/Dependencies/xr/Source/ARKit/XR.mm
+++ b/Dependencies/xr/Source/ARKit/XR.mm
@@ -1525,6 +1525,8 @@ namespace xr {
         , RemovedPlanes{}
         , UpdatedMeshes{}
         , RemovedMeshes{}
+        , UpdatedImageTrackingResults{}
+        , RemovedImageTrackingResults{}
         , IsTracking{sessionImpl.IsTracking()}
         , m_impl{ std::make_unique<System::Session::Frame::Impl>(sessionImpl) } {
         Views[0].DepthNearZ = sessionImpl.DepthNearZ;

--- a/Dependencies/xr/Source/OpenXR/SceneUnderstanding.cpp
+++ b/Dependencies/xr/Source/OpenXR/SceneUnderstanding.cpp
@@ -212,7 +212,6 @@ private:
     {
         xr::su::ScenePlane::Extent Size;
     };
-    struct ImageTrackingResult : System::Session::Frame::ImageTrackingResult {};
 
     void Enable(const InitOptions& options)
     {
@@ -243,8 +242,6 @@ private:
         m_removedMeshes.clear();
         m_updatedPlanes.clear();
         m_removedPlanes.clear();
-        m_updatedImageTrackingResults.clear();
-        m_removedImageTrackingResults.clear();
     }
 
     void UpdateSceneData(UpdateFrameArgs& args)
@@ -253,8 +250,6 @@ private:
         UpdateSceneObjects();
         UpdateMeshes(args);
         UpdatePlanes(args);
-        // TODO - Do I need this?
-        //UpdateImageTrackingResults(args);
     }
 
     void UpdateSceneObjects()
@@ -468,12 +463,6 @@ private:
 
         args.RemovedPlanes.clear();
         m_removedPlanes.swap(args.RemovedPlanes);
-
-        args.UpdatedImageTrackingResults.clear();
-        m_updatedImageTrackingResults.swap(args.UpdatedImageTrackingResults);
-
-        args.RemovedImageTrackingResults.clear();
-        m_removedImageTrackingResults.swap(args.RemovedImageTrackingResults);
     }
 
     std::unique_ptr<xr::su::SceneObserver> m_sceneObserver;
@@ -495,8 +484,6 @@ private:
     std::vector<Mesh::Identifier> m_removedMeshes{};
     std::vector<Plane::Identifier> m_updatedPlanes{};
     std::vector<Plane::Identifier> m_removedPlanes{};
-    std::vector<ImageTrackingResult::Identifier> m_updatedImageTrackingResults;
-    std::vector<ImageTrackingResult::Identifier> m_removedImageTrackingResults;
 
     const std::unordered_map<xr::su::SceneObject::Type, xr::SceneObjectType> c_objectTypeMap
     {

--- a/Dependencies/xr/Source/OpenXR/SceneUnderstanding.cpp
+++ b/Dependencies/xr/Source/OpenXR/SceneUnderstanding.cpp
@@ -212,6 +212,7 @@ private:
     {
         xr::su::ScenePlane::Extent Size;
     };
+    struct ImageTrackingResult : System::Session::Frame::ImageTrackingResult {};
 
     void Enable(const InitOptions& options)
     {
@@ -242,6 +243,8 @@ private:
         m_removedMeshes.clear();
         m_updatedPlanes.clear();
         m_removedPlanes.clear();
+        m_updatedImageTrackingResults.clear();
+        m_removedImageTrackingResults.clear();
     }
 
     void UpdateSceneData(UpdateFrameArgs& args)
@@ -250,6 +253,8 @@ private:
         UpdateSceneObjects();
         UpdateMeshes(args);
         UpdatePlanes(args);
+        // TODO - Do I need this?
+        //UpdateImageTrackingResults(args);
     }
 
     void UpdateSceneObjects()
@@ -463,6 +468,12 @@ private:
 
         args.RemovedPlanes.clear();
         m_removedPlanes.swap(args.RemovedPlanes);
+
+        args.UpdatedImageTrackingResults.clear();
+        m_updatedImageTrackingResults.swap(args.UpdatedImageTrackingResults);
+
+        args.RemovedImageTrackingResults.clear();
+        m_removedImageTrackingResults.swap(args.RemovedImageTrackingResults);
     }
 
     std::unique_ptr<xr::su::SceneObserver> m_sceneObserver;
@@ -484,6 +495,8 @@ private:
     std::vector<Mesh::Identifier> m_removedMeshes{};
     std::vector<Plane::Identifier> m_updatedPlanes{};
     std::vector<Plane::Identifier> m_removedPlanes{};
+    std::vector<ImageTrackingResult::Identifier> m_updatedImageTrackingResults;
+    std::vector<ImageTrackingResult::Identifier> m_removedImageTrackingResults;
 
     const std::unordered_map<xr::su::SceneObject::Type, xr::SceneObjectType> c_objectTypeMap
     {

--- a/Dependencies/xr/Source/OpenXR/SceneUnderstanding.h
+++ b/Dependencies/xr/Source/OpenXR/SceneUnderstanding.h
@@ -37,6 +37,8 @@ namespace xr
             std::vector<System::Session::Frame::Plane::Identifier>& RemovedPlanes;
             std::vector<System::Session::Frame::Mesh::Identifier>& UpdatedMeshes;
             std::vector<System::Session::Frame::Mesh::Identifier>& RemovedMeshes;
+            std::vector<System::Session::Frame::ImageTrackingResult::Identifier>UpdatedImageTrackingResults;
+            std::vector<System::Session::Frame::ImageTrackingResult::Identifier>RemovedImageTrackingResults;
         };
 
         SceneUnderstanding();

--- a/Dependencies/xr/Source/OpenXR/XR.cpp
+++ b/Dependencies/xr/Source/OpenXR/XR.cpp
@@ -910,6 +910,8 @@ namespace xr
         , RemovedPlanes{}
         , UpdatedMeshes{}
         , RemovedMeshes{}
+        , UpdatedImageTrackingResults{}
+        , RemovedImageTrackingResults{}
         // TODO - https://github.com/BabylonJS/BabylonNative/issues/505
         // Plumb tracking states from OpenXR. For now this will maintain the current behavior where BabylonJS assumes tracking is always available.
         , IsTracking{true}
@@ -1036,7 +1038,9 @@ namespace xr
                 UpdatedPlanes,
                 RemovedPlanes,
                 UpdatedMeshes,
-                RemovedMeshes
+                RemovedMeshes,
+                UpdatedImageTrackingResults,
+                RemovedImageTrackingResults,
             };
             sceneUnderstanding.UpdateFrame(suUpdateArgs);
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2297,6 +2297,11 @@ namespace Babylon
                 return m_sceneObjects.at(objectID).Value();
             }
 
+            std::vector<XRImageTrackingScore> GetXRImageTrackingScores()
+            {
+                // TODO
+            }
+
         private:
             const xr::System::Session::Frame* m_frame{};
             Napi::ObjectReference m_jsXRViewerPose{};
@@ -2753,7 +2758,7 @@ namespace Babylon
                         InstanceMethod("trySetPreferredPlaneDetectorOptions", &XRSession::TrySetPreferredPlaneDetectorOptions),
                         InstanceMethod("trySetMeshDetectorEnabled", &XRSession::TrySetMeshDetectorEnabled),
                         InstanceMethod("trySetPreferredMeshDetectorOptions", &XRSession::TrySetPreferredMeshDetectorOptions),
-                        // TODO: Is this where I add getTrackedImageScores?
+                        InstanceMethod("getTrackedImageScores", &XRSession::GetTrackedImageScores),
                     });
 
                 env.Global().Set(JS_CLASS_NAME, func);
@@ -3267,6 +3272,14 @@ namespace Babylon
                 const auto options = CreateDetectorOptions(info[0].As<Napi::Object>());
                 const auto result = m_xr->TrySetPreferredMeshDetectorOptions(options);
                 return Napi::Value::From(info.Env(), result);
+            }
+
+            Napi::Value GetTrackedImageScores(const Napi::CallbackInfo& info)
+            {
+                auto xrScores = m_xrFrame.GetXRImageTrackingScores();
+
+                // TODO: Is there any more parsing needed?
+                return Napi::Value::From(info.Env(), xrScores);
             }
         };
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -2247,11 +2247,6 @@ namespace Babylon
                 return m_sceneObjects.at(objectID).Value();
             }
 
-            std::vector<XRImageTrackingScore> GetXRImageTrackingScores()
-            {
-                // TODO
-            }
-
         private:
             const xr::System::Session::Frame* m_frame{};
             Napi::ObjectReference m_jsXRViewerPose{};
@@ -2734,6 +2729,18 @@ namespace Babylon
                             }
                         });
 
+                // If created with images to track, set the scores of the images
+                auto featureObject = info[1].As<Napi::Object>();
+                if (featureObject.Has("trackedImages"))
+                {
+                    auto trackedImages = featureObject.Get("trackedImages").As<Napi::Array>();
+                    for (auto idx = 0; idx < trackedImages.Length(); idx++)
+                    {
+                        // TODO : Call native to get tracking score
+                        m_imageTrackingScores[idx] = "trackable";
+                    }
+                }
+
                 return deferred.Promise();
             }
 
@@ -2805,6 +2812,7 @@ namespace Babylon
             Napi::ObjectReference m_jsEyeTrackedSource{};
             std::vector<xr::System::Session::Frame::InputSource::Identifier> m_activeSelects{};
             std::vector<xr::System::Session::Frame::InputSource::Identifier> m_activeSqueezes{};
+            static std::vector<char*> m_imageTrackingScores;
 
             Napi::Value GetInputSources(const Napi::CallbackInfo& /*info*/)
             {
@@ -3226,10 +3234,8 @@ namespace Babylon
 
             Napi::Value GetTrackedImageScores(const Napi::CallbackInfo& info)
             {
-                auto xrScores = m_xrFrame.GetXRImageTrackingScores();
-
                 // TODO: Is there any more parsing needed?
-                return Napi::Value::From(info.Env(), xrScores);
+                return Napi::Value::From(info.Env(), m_imageTrackingScores);
             }
         };
 

--- a/Plugins/NativeXr/Source/NativeXr.cpp
+++ b/Plugins/NativeXr/Source/NativeXr.cpp
@@ -1701,7 +1701,7 @@ namespace Babylon
         };
 
         // Implementation of the XRTrackedImageInit: https://immersive-web.github.io/marker-tracking/#dictdef-xrtrackedimageinit
-        // TODO: Where in the WebXRImageTracking is this used? Does it need to be here?
+        // TODO: Where in the WebXRImageTracking feature is this used? Does it need to be here?
         class XRTrackedImageInit : public Napi::ObjectWrap<XRTrackedImageInit>
         {
             static constexpr auto JS_CLASS_NAME = "XRTrackedImageInit";
@@ -2662,7 +2662,7 @@ namespace Babylon
                         Napi::Object napiSpace = XRReferenceSpace::New(info.Env(), napiImageTransform);
                         napiImageTrackingResult.Set("imageSpace", napiSpace);
 
-                        // Where do these values come from?
+                        // TODO: Where do these values come from?
                         napiImageTrackingResult.Set("index", 0);
                         napiImageTrackingResult.Set("trackingState", someEnumValue);
                         napiImageTrackingResult.Set("measuredWidthInMeters", someFloatValue);


### PR DESCRIPTION
This PR currently has these changes:

1. Adds structs for passing results between the ARCore layer and the Napi layer. (For ImageTrackingBitmap, that's data coming from [NativeEngine::CreateImageBitmap](https://github.com/BabylonJS/Babylon.js/blob/master/src/XR/features/WebXRImageTracking.ts#:~:text=_xrSessionManager.scene.getEngine().-,createImageBitmap,-(img).then((imageBitmap))

2. When the XRSession is created, accept the image tracking params [(described here)](https://github.com/immersive-web/marker-tracking/blob/main/explainer.md) and then creates the ArAugmentedImageDatabase [based on this example](https://github.com/google-ar/arcore-android-sdk/blob/06573b8e1f3ef336084c9a0ee627937246896ea0/samples/augmented_image_c/app/src/main/cpp/augmented_image_application.cc#:~:text=AugmentedImageApplication%3A%3ACreateAugmentedImageDatabase()%20const%20%7B)

3. During image database creation, ImageTrackingScore's are assigned and don't change after init, so they're stored in the XRSession and can be pulled with GetTrackedImageScores

4. During the ARCore Frame's update, call UpdateImageTrackingResults to maintain an ImageTrackingResult array

5. During the XRFrame's update, it has it's own UpdateImageTrackingResults that pulls from the ARCore Frame's results

6. Changed XRRigidTransform::New to take info.Env() instead of info; Renamed ARCore's trackableList to trackablePlanesList for clarity.